### PR TITLE
LMSR fixups and migration to Truffle 5

### DIFF
--- a/contracts/MarketMaker.sol
+++ b/contracts/MarketMaker.sol
@@ -29,7 +29,6 @@ contract MarketMaker is Ownable, IERC1155TokenReceiver {
 
     uint64 public fee;
     uint public funding;
-    int[] public netOutcomeTokensSold;
     Stages public stage;
     enum Stages {
         MarketCreated,
@@ -54,11 +53,6 @@ contract MarketMaker is Ownable, IERC1155TokenReceiver {
         pmSystem = _pmSystem;
         collateralToken = _collateralToken;
         conditionId = _conditionId;
-
-        uint outcomeSlotCount = pmSystem.getOutcomeSlotCount(conditionId);
-        require(outcomeSlotCount > 0);
-        netOutcomeTokensSold = new int[](outcomeSlotCount);
-
         fee = _fee;
         stage = Stages.MarketCreated;
     }
@@ -159,7 +153,6 @@ contract MarketMaker is Ownable, IERC1155TokenReceiver {
                     pmSystem.safeTransferFrom(this, msg.sender, positionId, uint(outcomeTokenAmounts[i]), "");
                 }
 
-                netOutcomeTokensSold[i] = netOutcomeTokensSold[i].add(outcomeTokenAmounts[i]);
             }
         }
 
@@ -206,7 +199,7 @@ contract MarketMaker is Ownable, IERC1155TokenReceiver {
     }
 
     function generateBasicPositionId(uint i)
-        private
+        internal
         view
         returns (uint)
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1199,6 +1199,12 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
       "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
     },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "dev": true
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -1395,12 +1401,6 @@
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-      "dev": true
-    },
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
@@ -1423,9 +1423,9 @@
       "dev": true
     },
     "camelcase": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
       "dev": true
     },
     "canonical-weth": {
@@ -1526,34 +1526,29 @@
       "dev": true
     },
     "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
         "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -2077,15 +2072,6 @@
         "zeppelin-solidity": "^1.8.0"
       }
     },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
     "es6-promise": {
       "version": "2.3.0",
       "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
@@ -2465,6 +2451,21 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "execa": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "express": {
       "version": "4.16.4",
       "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
@@ -2644,13 +2645,12 @@
       }
     },
     "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -2969,12 +2969,6 @@
         "os-tmpdir": "^1.0.1"
       }
     },
-    "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-      "dev": true
-    },
     "http-errors": {
       "version": "1.6.3",
       "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -3152,21 +3146,6 @@
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
       "dev": true
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "^1.0.0"
-      }
-    },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
@@ -3245,12 +3224,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "isarray": {
@@ -3363,6 +3336,18 @@
         "verror": "1.10.0"
       }
     },
+    "keccak": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+      "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+      "dev": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.3",
+        "nan": "^2.2.1",
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "keccakjs": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
@@ -3401,29 +3386,20 @@
         "type-check": "~0.3.2"
       }
     },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
-    },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -3522,6 +3498,15 @@
       "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "mem": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
     },
     "memorystream": {
       "version": "0.3.1",
@@ -3762,18 +3747,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "normalize-package-data": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "is-builtin-module": "^1.0.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
     },
     "npm": {
       "version": "5.10.0",
@@ -7963,6 +7936,15 @@
         }
       }
     },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -8125,12 +8107,14 @@
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
-      "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -8150,6 +8134,24 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
     "p-timeout": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
@@ -8158,6 +8160,12 @@
       "requires": {
         "p-finally": "^1.0.0"
       }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "parse-asn1": {
       "version": "5.1.1",
@@ -8189,15 +8197,6 @@
         "trim": "0.0.1"
       }
     },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.2.0"
-      }
-    },
     "parseurl": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
@@ -8205,13 +8204,10 @@
       "dev": true
     },
     "path-exists": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "^2.0.0"
-      }
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -8235,17 +8231,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
       "dev": true
-    },
-    "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
     },
     "pathval": {
       "version": "1.1.0",
@@ -8484,27 +8469,6 @@
         "unpipe": "1.0.0"
       }
     },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      }
-    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -8612,9 +8576,9 @@
       "dev": true
     },
     "require-from-string": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz",
-      "integrity": "sha1-UpyczvJzgK3+yaL5ZbZJu+5jZBg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {
@@ -8905,16 +8869,17 @@
       }
     },
     "solc": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
-      "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.0.tgz",
+      "integrity": "sha512-mdLHDl9WeYrN+FIKcMc9PlPfnA9DG9ur5QpCDKcv6VC4RINAsTF4EMuXMZMKoQTvZhtLyJIVH/BZ+KU830Z8Xg==",
       "dev": true,
       "requires": {
         "fs-extra": "^0.30.0",
+        "keccak": "^1.0.2",
         "memorystream": "^0.3.1",
-        "require-from-string": "^1.1.0",
-        "semver": "^5.3.0",
-        "yargs": "^4.7.1"
+        "require-from-string": "^2.0.0",
+        "semver": "^5.5.0",
+        "yargs": "^11.0.0"
       },
       "dependencies": {
         "fs-extra": {
@@ -9250,38 +9215,6 @@
         "source-map": "^0.5.6"
       }
     },
-    "spdx-correct": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
-      "dev": true
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9367,15 +9300,6 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
     "strip-dirs": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
@@ -9384,6 +9308,12 @@
       "requires": {
         "is-natural-number": "^4.0.1"
       }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-hex-prefix": {
       "version": "1.0.0",
@@ -9649,14 +9579,14 @@
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "truffle": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.1.14.tgz",
-      "integrity": "sha512-e7tTLvKP3bN9dE7MagfWyFjy4ZgoEGbeujECy1me1ENBzbj/aO/+45gs72qsL3+3IkCNNcWNOJjjrm8BYZZNNg==",
+      "version": "5.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.0-beta.2.tgz",
+      "integrity": "sha512-D15MsJeKWRNxbx2Vmy50gH8z4gjBYecJIUADBBBL593hkVnhZ1ADgkIujCvvrbD6Pj69Vg5Ky/nJXl7M9TCjsg==",
       "dev": true,
       "requires": {
         "mocha": "^4.1.0",
         "original-require": "1.0.1",
-        "solc": "0.4.24"
+        "solc": "^0.5.0"
       }
     },
     "tslib": {
@@ -9824,16 +9754,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
     },
     "vary": {
       "version": "1.1.2",
@@ -10234,15 +10154,9 @@
       }
     },
     "which-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
-      "dev": true
-    },
-    "window-size": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "winston": {
@@ -10405,57 +10319,32 @@
       "dev": true
     },
     "yargs": {
-      "version": "4.8.1",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
-      "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+      "version": "11.1.0",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {
-        "cliui": "^3.2.0",
+        "cliui": "^4.0.0",
         "decamelize": "^1.1.1",
+        "find-up": "^2.1.0",
         "get-caller-file": "^1.0.1",
-        "lodash.assign": "^4.0.3",
-        "os-locale": "^1.4.0",
-        "read-pkg-up": "^1.0.1",
+        "os-locale": "^2.0.0",
         "require-directory": "^2.1.1",
         "require-main-filename": "^1.0.1",
         "set-blocking": "^2.0.0",
-        "string-width": "^1.0.1",
-        "which-module": "^1.0.0",
-        "window-size": "^0.2.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
         "y18n": "^3.2.1",
-        "yargs-parser": "^2.4.1"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        }
+        "yargs-parser": "^9.0.2"
       }
     },
     "yargs-parser": {
-      "version": "2.4.1",
-      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
-      "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
       "dev": true,
       "requires": {
-        "camelcase": "^3.0.0",
-        "lodash.assign": "^4.0.6"
+        "camelcase": "^4.1.0"
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lodash": "^4.17.4",
     "npm-prepublish": "^1.2.3",
     "solhint": "^1.1.10",
-    "truffle": "^4.0.4",
+    "truffle": "^5.0.0-beta.2",
     "web3": "^1.0.0-beta.35"
   },
   "repository": {

--- a/test/test_market_makers.js
+++ b/test/test_market_makers.js
@@ -1,10 +1,10 @@
 const _ = require('lodash')
 const testGas = require('@gnosis.pm/truffle-nice-tools').testGas
-const NewWeb3 = require('web3')
 const { wait } = require('@digix/tempo')(web3)
 
 const utils = require('./utils')
 const { ONE, isClose, lmsrMarginalPrice, getParamFromTxEvent, getBlock, assertRejects, Decimal, randnums } = utils
+const { toBN, soliditySha3, toHex } = web3.utils
 
 const PredictionMarketSystem = artifacts.require('PredictionMarketSystem')
 const LMSRMarketMakerFactory = artifacts.require('LMSRMarketMakerFactory')
@@ -33,7 +33,7 @@ contract('MarketMaker', function(accounts) {
         const netOutcomeTokensSold = new Array(numOutcomes).fill(0)
         const questionId = '0xf00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafe'
         const oracleAddress = accounts[1]
-        const conditionId = getParamFromTxEvent(
+        const conditionId = await getParamFromTxEvent(
             await pmSystem.prepareCondition(oracleAddress, questionId, numOutcomes),
             'conditionId')
 
@@ -41,57 +41,58 @@ contract('MarketMaker', function(accounts) {
         const investor = 0
 
         const feeFactor = 0  // 0%
-        const lmsrMarketMaker = getParamFromTxEvent(
+        const lmsrMarketMaker = await getParamFromTxEvent(
             await lmsrMarketMakerFactory.createLMSRMarketMaker(pmSystem.address, etherToken.address, conditionId, feeFactor,
                 { from: accounts[investor] }),
             'lmsrMarketMaker', LMSRMarketMaker)
 
         // Fund lmsrMarketMaker
-        const funding = 1e17
+        const funding = toBN(1e17)
 
         await etherToken.deposit({ value: funding, from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]).then(v => v.toString()), funding.toString())
 
         await etherToken.approve(lmsrMarketMaker.address, funding, { from: accounts[investor] })
         await lmsrMarketMaker.fund(funding, { from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf.call(accounts[investor]), 0)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]).then(v => v.toString()), '0')
 
         // User buys all outcomes
         const trader = 1
         const outcome = 1
-        const positionId = NewWeb3.utils.soliditySha3(
+        const positionId = soliditySha3(
                 { t: 'address', v: etherToken.address },
-                { t: 'bytes32', v: NewWeb3.utils.soliditySha3(
+                { t: 'bytes32', v: soliditySha3(
                     { t: 'bytes32', v: conditionId },
                     { t: 'uint', v: 1 << outcome },
                 )}
             )
-        const tokenCount = 1e18
-        const loopCount = 10
+        const tokenCountRaw = 1e18
+        const tokenCount = toBN(tokenCountRaw)
+        const loopCount = toBN(10)
 
-        await etherToken.deposit({ value: tokenCount * loopCount, from: accounts[trader] })
-        await etherToken.approve(pmSystem.address, tokenCount * loopCount, { from: accounts[trader] })
-        await pmSystem.splitPosition(etherToken.address, "0x00", conditionId, [...Array(numOutcomes).keys()].map(i => 1 << i), tokenCount * loopCount, { from: accounts[trader] })
+        await etherToken.deposit({ value: tokenCount.mul(loopCount), from: accounts[trader] })
+        await etherToken.approve(pmSystem.address, tokenCount.mul(loopCount), { from: accounts[trader] })
+        await pmSystem.splitPosition(etherToken.address, "0x00", conditionId, [...Array(numOutcomes).keys()].map(i => 1 << i), tokenCount.mul(loopCount), { from: accounts[trader] })
         await pmSystem.setApprovalForAll(lmsrMarketMaker.address, true, { from: accounts[trader] })
 
         // User sells tokens
         const buyerBalance = await etherToken.balanceOf.call(accounts[trader])
         let profit, outcomeTokenAmounts
-        for(const i of _.range(loopCount)) {
+        for(const i of _.range(loopCount.toNumber())) {
             // Calculate profit for selling tokens
-            outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? -tokenCount : 0)
+            outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? tokenCount.neg() : toBN(0))
             profit = (await lmsrMarketMaker.calcNetCost.call(outcomeTokenAmounts)).neg()
-            if(profit == 0)
+            if(profit.eqn(0))
                 break
 
             // Selling tokens
-            assert.equal(getParamFromTxEvent(
+            assert.equal((await getParamFromTxEvent(
                 await lmsrMarketMaker.trade(outcomeTokenAmounts, profit.neg(), { from: accounts[trader] }), 'outcomeTokenNetCost'
-            ).neg().valueOf(), profit.valueOf())
+            )).neg().toString(), profit.toString())
 
-            netOutcomeTokensSold[outcome] -= tokenCount
+            netOutcomeTokensSold[outcome] -= tokenCountRaw
             const expected = lmsrMarginalPrice(funding, netOutcomeTokensSold, outcome)
-            const actual = (await lmsrMarketMaker.calcMarginalPrice.call(outcome)).div(ONE)
+            const actual = new Decimal(await lmsrMarketMaker.calcMarginalPrice.call(toBN(outcome)).then(v => v.toString())).div(ONE)
             assert(
                 isClose(actual, expected),
                 `Marginal price calculation is off for iteration ${i}:\n` +
@@ -112,54 +113,55 @@ contract('MarketMaker', function(accounts) {
         const numOutcomes = 2
         const questionId = '0xf00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafe'
         const oracleAddress = accounts[5]
-        const conditionId = getParamFromTxEvent(
-            await pmSystem.prepareCondition(oracleAddress, questionId, numOutcomes),
+        const conditionId = await getParamFromTxEvent(
+            await pmSystem.prepareCondition(oracleAddress, questionId, toBN(numOutcomes)),
             'conditionId')
 
-        for(let [investor, funding, tokenCount] of [
-            [2, 1e17, 1e18],
-            [3, 1, 10],
-            [4, 1, 1e18],
+        for(const [investor, funding, tokenCountRaw] of [
+            [2, toBN(1e17), 1e18],
+            [3, toBN(1), 10],
+            [4, toBN(1), 1e18],
         ]) {
+            const tokenCount = toBN(tokenCountRaw)
             const netOutcomeTokensSold = new Array(numOutcomes).fill(0)
 
             // Create lmsrMarketMaker
             const feeFactor = 0  // 0%
-            const lmsrMarketMaker = getParamFromTxEvent(
+            const lmsrMarketMaker = await getParamFromTxEvent(
                 await lmsrMarketMakerFactory.createLMSRMarketMaker(pmSystem.address, etherToken.address, conditionId, feeFactor,
                     { from: accounts[investor] }),
                 'lmsrMarketMaker', LMSRMarketMaker)
 
             // Fund lmsrMarketMaker
             await etherToken.deposit({ value: funding, from: accounts[investor] })
-            assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding)
+            assert.equal(await etherToken.balanceOf.call(accounts[investor]).then(v => v.toString()), funding.toString())
 
             await etherToken.approve(lmsrMarketMaker.address, funding, { from: accounts[investor] })
             await lmsrMarketMaker.fund(funding, { from: accounts[investor] })
-            assert.equal(await etherToken.balanceOf.call(accounts[investor]), 0)
+            assert.equal(await etherToken.balanceOf.call(accounts[investor]).then(v => v.toString()), '0')
 
             // User buys ether tokens
             const trader = 1
             const outcome = 1
             const loopCount = 10
-            await etherToken.deposit({ value: tokenCount * loopCount, from: accounts[trader] })
+            await etherToken.deposit({ value: tokenCount.muln(loopCount), from: accounts[trader] })
 
             // User buys outcome tokens from lmsrMarketMaker maker
             let cost, outcomeTokenAmounts
             for(const i of _.range(loopCount)) {
                 // Calculate cost of buying tokens
-                outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? tokenCount : 0)
+                outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? tokenCount : toBN(0))
                 cost = await lmsrMarketMaker.calcNetCost.call(outcomeTokenAmounts)
 
                 // Buying tokens
                 await etherToken.approve(lmsrMarketMaker.address, cost, { from: accounts[trader] })
-                assert.equal(getParamFromTxEvent(
+                assert.equal(await getParamFromTxEvent(
                     await lmsrMarketMaker.trade(outcomeTokenAmounts, cost, { from: accounts[trader] }), 'outcomeTokenNetCost'
-                ).valueOf(), cost.valueOf())
+                ).then(v => v.toString()), cost.toString())
 
-                netOutcomeTokensSold[outcome] += tokenCount
+                netOutcomeTokensSold[outcome] += tokenCountRaw
                 const expected = lmsrMarginalPrice(funding, netOutcomeTokensSold, outcome)
-                const actual = (await lmsrMarketMaker.calcMarginalPrice.call(outcome)).div(ONE)
+                const actual = new Decimal(await lmsrMarketMaker.calcMarginalPrice.call(toBN(outcome)).then(v => v.toString())).div(ONE)
                 assert(
                     isClose(actual, expected) || expected.toString() == 'NaN',
                     `Marginal price calculation is off for iteration ${i}:\n` +
@@ -180,61 +182,61 @@ contract('MarketMaker', function(accounts) {
         const numOutcomes = 4
         const questionId = '0xf00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafef00dcafe'
         const oracleAddress = accounts[1]
-        const conditionId = getParamFromTxEvent(
-            await pmSystem.prepareCondition(oracleAddress, questionId, numOutcomes),
+        const conditionId = await getParamFromTxEvent(
+            await pmSystem.prepareCondition(oracleAddress, questionId, toBN(numOutcomes)),
             'conditionId')
 
         // Create lmsrMarketMaker
         const investor = 5
 
-        const feeFactor = 0  // 0%
-        const lmsrMarketMaker = getParamFromTxEvent(
+        const feeFactor = toBN(0)  // 0%
+        const lmsrMarketMaker = await getParamFromTxEvent(
             await lmsrMarketMakerFactory.createLMSRMarketMaker(pmSystem.address, etherToken.address, conditionId, feeFactor,
                 { from: accounts[investor] }),
             'lmsrMarketMaker', LMSRMarketMaker)
 
         // Fund lmsrMarketMaker
-        const funding = 1e18
+        const funding = toBN(1e18)
 
         await etherToken.deposit({ value: funding, from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]).then(v => v.toString()), funding.toString())
 
         await etherToken.approve(lmsrMarketMaker.address, funding, { from: accounts[investor] })
         await lmsrMarketMaker.fund(funding, { from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf.call(accounts[investor]), 0)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]).then(v => v.toString()), '0')
 
         const trader = 6
-        const initialOutcomeTokenCount = 1e18
-        const initialWETH9Count = 10e18
+        const initialOutcomeTokenCount = toBN(1e18)
+        const initialWETH9Count = toBN(10e18)
 
         // User buys all outcomes
-        await etherToken.deposit({ value: initialOutcomeTokenCount + initialWETH9Count, from: accounts[trader] })
+        await etherToken.deposit({ value: initialOutcomeTokenCount.add(initialWETH9Count), from: accounts[trader] })
         await etherToken.approve(pmSystem.address, initialOutcomeTokenCount, { from: accounts[trader] })
-        await pmSystem.splitPosition(etherToken.address, "0x00", conditionId, [...Array(numOutcomes).keys()].map(i => 1 << i), initialOutcomeTokenCount, { from: accounts[trader] })
+        await pmSystem.splitPosition(etherToken.address, "0x00", conditionId, [...Array(numOutcomes).keys()].map(i => toBN(1 << i)), initialOutcomeTokenCount, { from: accounts[trader] })
 
         // User trades with the lmsrMarketMaker
-        const tradeValues = [5e17, -1e18, -1e17, 2e18]
+        const tradeValues = [5e17, -1e18, -1e17, 2e18].map(toBN)
         const cost = await lmsrMarketMaker.calcNetCost.call(tradeValues)
-        if(cost.gt(0)) await etherToken.approve(lmsrMarketMaker.address, cost, { from: accounts[trader] })
+        if(cost.gtn(0)) await etherToken.approve(lmsrMarketMaker.address, cost, { from: accounts[trader] })
 
         await pmSystem.setApprovalForAll(lmsrMarketMaker.address, true, { from: accounts[trader] })
 
-        assert.equal(getParamFromTxEvent(
+        assert.equal(await getParamFromTxEvent(
             await lmsrMarketMaker.trade(tradeValues, cost, { from: accounts[trader] }), 'outcomeTokenNetCost'
-        ), cost.valueOf())
+        ).then(v => v.toString()), cost.toString())
 
         // All state transitions associated with trade have been performed
-        for(let [tradeValue, i] of tradeValues.map((v, i) => [v, i])) {
-            assert.equal(await pmSystem.balanceOf.call(accounts[trader], NewWeb3.utils.soliditySha3(
+        for(const [tradeValue, i] of tradeValues.map((v, i) => [v, i])) {
+            assert.equal(await pmSystem.balanceOf.call(accounts[trader], soliditySha3(
                 { t: 'address', v: etherToken.address },
-                { t: 'bytes32', v: NewWeb3.utils.soliditySha3(
+                { t: 'bytes32', v: soliditySha3(
                     { t: 'bytes32', v: conditionId },
                     { t: 'uint', v: 1 << i },
                 )}
-            )).then(v => v.valueOf()), initialOutcomeTokenCount + tradeValue)
+            )).then(v => v.toString()), initialOutcomeTokenCount.add(tradeValue))
         }
 
-        assert.equal(await etherToken.balanceOf.call(accounts[trader]), initialWETH9Count - cost.valueOf())
+        assert.equal(await etherToken.balanceOf.call(accounts[trader]).then(v => v.toString()), initialWETH9Count.sub(cost).toString())
     })
 })
 
@@ -261,8 +263,8 @@ contract('LMSRMarketMaker', function (accounts) {
         // create event
         centralizedOracle = accounts[1]
         questionId++
-        conditionId = getParamFromTxEvent(
-            await pmSystem.prepareCondition(centralizedOracle, questionId, numOutcomes),
+        conditionId = await getParamFromTxEvent(
+            await pmSystem.prepareCondition(centralizedOracle, toHex(questionId), toBN(numOutcomes)),
             'conditionId')
     })
 
@@ -270,28 +272,28 @@ contract('LMSRMarketMaker', function (accounts) {
         // Create lmsrMarketMaker
         const buyer = 5
 
-        const feeFactor = 0
-        const lmsrMarketMaker = getParamFromTxEvent(
+        const feeFactor = toBN(0)
+        const lmsrMarketMaker = await getParamFromTxEvent(
             await lmsrMarketMakerFactory.createLMSRMarketMaker(pmSystem.address, etherToken.address, conditionId, feeFactor, { from: accounts[buyer] }),
             'lmsrMarketMaker', LMSRMarketMaker
         )
 
         // Fund lmsrMarketMaker
-        const funding = 100
+        const funding = toBN(100)
 
         await etherToken.deposit({ value: funding, from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), funding)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]).then(v => v.toString()), funding.toString())
 
         await etherToken.approve(lmsrMarketMaker.address, funding, { from: accounts[buyer] })
         await lmsrMarketMaker.fund(funding, { from: accounts[buyer] })
 
         // LMSRMarketMaker can only be funded once
         await etherToken.deposit({ value: funding, from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), funding)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]).then(v => v.toString()), funding.toString())
         await etherToken.approve(lmsrMarketMaker.address, funding, { from: accounts[buyer] })
         await assertRejects(lmsrMarketMaker.fund(funding, { from: accounts[buyer] }), 'lmsrMarketMaker funded twice')
 
-        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), funding)
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]).then(v => v.toString()), funding.toString())
 
         // Close lmsrMarketMaker
         await lmsrMarketMaker.close({ from: accounts[buyer] })
@@ -301,160 +303,161 @@ contract('LMSRMarketMaker', function (accounts) {
 
         // Sell all outcomes
         await pmSystem.setApprovalForAll(lmsrMarketMaker.address, true, { from: accounts[buyer] })
-        await pmSystem.mergePositions(etherToken.address, '0x00', conditionId, [...Array(numOutcomes).keys()].map(i => 1 << i), funding, { from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), funding * 2)
+        await pmSystem.mergePositions(etherToken.address, '0x00', conditionId, [...Array(numOutcomes).keys()].map(i => toBN(1 << i)), funding, { from: accounts[buyer] })
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]).then(v => v.toString()), funding.muln(2).toString())
     })
 
     it('should allow buying and selling', async () => {
         // create lmsrMarketMaker
         const investor = 0
 
-        const feeFactor = 5e16  // 5%
-        const lmsrMarketMaker = getParamFromTxEvent(
+        const feeFactor = toBN(5e16)  // 5%
+        const lmsrMarketMaker = await getParamFromTxEvent(
             await lmsrMarketMakerFactory.createLMSRMarketMaker(pmSystem.address, etherToken.address, conditionId, feeFactor, { from: accounts[investor] }),
             'lmsrMarketMaker', LMSRMarketMaker
         )
 
         // Fund lmsrMarketMaker
-        const funding = 1e18
+        const funding = toBN(1e18)
 
         await etherToken.deposit({ value: funding, from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf.call(accounts[investor]), funding)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]).then(v => v.toString()), funding.toString())
 
         await etherToken.approve(lmsrMarketMaker.address, funding, { from: accounts[investor] })
 
         await lmsrMarketMaker.fund(funding, { from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf.call(accounts[investor]), 0)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]).then(v => v.toString()), '0')
 
         // Buy outcome tokens
         const buyer = 1
         const outcome = 0
-        const positionId = NewWeb3.utils.soliditySha3(
+        const positionId = soliditySha3(
                 { t: 'address', v: etherToken.address },
-                { t: 'bytes32', v: NewWeb3.utils.soliditySha3(
+                { t: 'bytes32', v: soliditySha3(
                     { t: 'bytes32', v: conditionId },
                     { t: 'uint', v: 1 << outcome },
                 )}
             )
-        const tokenCount = 1e15
-        let outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? tokenCount : 0)
+        const tokenCount = toBN(1e15)
+        let outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? tokenCount : toBN(0))
         const outcomeTokenCost = await lmsrMarketMaker.calcNetCost.call(outcomeTokenAmounts)
 
         let fee = await lmsrMarketMaker.calcMarketFee.call(outcomeTokenCost)
-        assert.equal(fee, Math.floor(outcomeTokenCost * 5 / 100))
+        assert.equal(fee.toString(), outcomeTokenCost.muln(5).divn(100).toString())
 
         const cost = fee.add(outcomeTokenCost)
         await etherToken.deposit({ value: cost, from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), cost.valueOf())
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]).then(v => v.toString()), cost.toString())
 
         await etherToken.approve(lmsrMarketMaker.address, cost, { from: accounts[buyer] })
-        assert.equal(getParamFromTxEvent(
+        assert.equal(await getParamFromTxEvent(
             await lmsrMarketMaker.trade(outcomeTokenAmounts, cost, { from: accounts[buyer] }), 'outcomeTokenNetCost'
-        ), outcomeTokenCost.valueOf())
+        ), outcomeTokenCost.toString())
 
-        assert.equal(await pmSystem.balanceOf.call(accounts[buyer], positionId), tokenCount)
-        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), 0)
+        assert.equal(await pmSystem.balanceOf.call(accounts[buyer], positionId).then(v => v.toString()), tokenCount.toString())
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]).then(v => v.toString()), 0)
 
         // Sell outcome tokens
-        outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? -tokenCount : 0)
+        outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i === outcome ? tokenCount.neg() : toBN(0))
         const outcomeTokenProfit = (await lmsrMarketMaker.calcNetCost.call(outcomeTokenAmounts)).neg()
         fee = await lmsrMarketMaker.calcMarketFee.call(outcomeTokenProfit)
         const profit = outcomeTokenProfit.sub(fee)
 
         await pmSystem.setApprovalForAll(lmsrMarketMaker.address, true, { from: accounts[buyer] })
-        assert.equal(getParamFromTxEvent(
-            await lmsrMarketMaker.trade(outcomeTokenAmounts, -profit, { from: accounts[buyer] }), 'outcomeTokenNetCost'
-        ).neg().valueOf(), outcomeTokenProfit.valueOf())
+        assert.equal(await getParamFromTxEvent(
+            await lmsrMarketMaker.trade(outcomeTokenAmounts, profit.neg(), { from: accounts[buyer] }), 'outcomeTokenNetCost'
+        ).then(v => v.neg().toString()), outcomeTokenProfit.toString())
 
-        assert.equal(await pmSystem.balanceOf.call(accounts[buyer], positionId), 0)
-        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), profit.valueOf())
+        assert.equal(await pmSystem.balanceOf.call(accounts[buyer], positionId).then(v => v.toString()), '0')
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]).then(v => v.toString()), profit.toString())
     })
 
     it('should allow short selling', async () => {
         // create lmsrMarketMaker
         const investor = 7
 
-        const feeFactor = 50000  // 5%
-        const lmsrMarketMaker = getParamFromTxEvent(
+        const feeFactor = toBN(50000)  // 5%
+        const lmsrMarketMaker = await getParamFromTxEvent(
             await lmsrMarketMakerFactory.createLMSRMarketMaker(pmSystem.address, etherToken.address, conditionId, feeFactor, { from: accounts[investor] }),
             'lmsrMarketMaker', LMSRMarketMaker
         )
 
         // Fund lmsrMarketMaker
-        const funding = 1e18
+        const funding = toBN(1e18)
 
         await etherToken.deposit({ value: funding, from: accounts[investor] })
-        assert.equal((await etherToken.balanceOf.call(accounts[investor])).valueOf(), funding)
+        assert.equal((await etherToken.balanceOf.call(accounts[investor])).toString(), funding.toString())
 
         await etherToken.approve(lmsrMarketMaker.address, funding, { from: accounts[investor] })
 
         await lmsrMarketMaker.fund(funding, { from: accounts[investor] })
-        assert.equal(await etherToken.balanceOf.call(accounts[investor]), 0)
+        assert.equal(await etherToken.balanceOf.call(accounts[investor]).then(v => v.toString()), '0')
 
         // Short sell outcome tokens
         const buyer = 7
         const outcome = 0
         const differentOutcome = 1
-        const differentPositionId = NewWeb3.utils.soliditySha3(
+        const differentPositionId = soliditySha3(
                 { t: 'address', v: etherToken.address },
-                { t: 'bytes32', v: NewWeb3.utils.soliditySha3(
+                { t: 'bytes32', v: soliditySha3(
                     { t: 'bytes32', v: conditionId },
                     { t: 'uint', v: 1 << differentOutcome },
                 )}
             )
-        const tokenCount = 1e15
-        const outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i !== outcome ? tokenCount : 0)
+        const tokenCount = toBN(1e15)
+        const outcomeTokenAmounts = Array.from({length: numOutcomes}, (v, i) => i !== outcome ? tokenCount : toBN(0))
         const outcomeTokenCost = await lmsrMarketMaker.calcNetCost.call(outcomeTokenAmounts)
         const fee = await lmsrMarketMaker.calcMarketFee.call(outcomeTokenCost)
         const cost = outcomeTokenCost.add(fee)
 
         await etherToken.deposit({ value: cost, from: accounts[buyer] })
-        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), cost.valueOf())
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]).then(v => v.toString()), cost.toString())
         await etherToken.approve(lmsrMarketMaker.address, cost, { from: accounts[buyer] })
 
         assert.equal(
-            getParamFromTxEvent(
+            await getParamFromTxEvent(
                 await lmsrMarketMaker.trade(outcomeTokenAmounts, cost, { from: accounts[buyer] }),
                 'outcomeTokenNetCost'
-            ).valueOf(), outcomeTokenCost.valueOf())
-        assert.equal(await etherToken.balanceOf.call(accounts[buyer]), 0)
-        assert.equal(await pmSystem.balanceOf.call(accounts[buyer], differentPositionId), tokenCount)
+            ).then(v => v.toString()), outcomeTokenCost.toString())
+        assert.equal(await etherToken.balanceOf.call(accounts[buyer]).then(v => v.toString()), '0')
+        assert.equal(await pmSystem.balanceOf.call(accounts[buyer], differentPositionId).then(v => v.toString()), tokenCount.toString())
     })
 
     it('trading stress testing', async () => {
-        const MAX_VALUE = Decimal(2).pow(256).sub(1)
+        const MAX_VALUE = toBN(2).pow(toBN(256)).subn(1)
 
         const trader = 9
-        const feeFactor = 0
+        const feeFactor = toBN(0)
 
-        const lmsrMarketMaker = getParamFromTxEvent(
+        const lmsrMarketMaker = await getParamFromTxEvent(
             await lmsrMarketMakerFactory.createLMSRMarketMaker(pmSystem.address, etherToken.address, conditionId, feeFactor, { from: accounts[trader] }),
             'lmsrMarketMaker', LMSRMarketMaker
         )
 
-        const positionIds = [...Array(numOutcomes).keys()].map(i => NewWeb3.utils.soliditySha3(
+        const positionIds = [...Array(numOutcomes).keys()].map(i => soliditySha3(
                 { t: 'address', v: etherToken.address },
-                { t: 'bytes32', v: NewWeb3.utils.soliditySha3(
+                { t: 'bytes32', v: soliditySha3(
                     { t: 'bytes32', v: conditionId },
                     { t: 'uint', v: 1 << i },
                 )}
             ))
 
         // Get ready for trading
-        await etherToken.deposit({ value: 2e19, from: accounts[trader] })
-        await etherToken.approve(pmSystem.address, 1e19, { from: accounts[trader] })
-        await pmSystem.splitPosition(etherToken.address, '0x00', conditionId, [...Array(numOutcomes).keys()].map(i => 1 << i), 1e19, { from: accounts[trader] })
+        tradingStipend = toBN(1e19)
+        await etherToken.deposit({ value: tradingStipend.muln(2), from: accounts[trader] })
+        await etherToken.approve(pmSystem.address, tradingStipend, { from: accounts[trader] })
+        await pmSystem.splitPosition(etherToken.address, '0x00', conditionId, [...Array(numOutcomes).keys()].map(i => 1 << i), tradingStipend, { from: accounts[trader] })
 
         // Allow all trading
-        await etherToken.approve(lmsrMarketMaker.address, MAX_VALUE.valueOf(), { from: accounts[trader] })
+        await etherToken.approve(lmsrMarketMaker.address, MAX_VALUE, { from: accounts[trader] })
         await pmSystem.setApprovalForAll(lmsrMarketMaker.address, true, { from: accounts[trader] })
 
         // Fund lmsrMarketMaker
-        const funding = 1e16
+        const funding = toBN(1e16)
         await lmsrMarketMaker.fund(funding, { from: accounts[trader] })
 
         for(let i = 0; i < 10; i++) {
-            const outcomeTokenAmounts = randnums(-1e16, 1e16, numOutcomes).map(n => n.valueOf())
+            const outcomeTokenAmounts = randnums(-1e16, 1e16, numOutcomes).map(n => toBN(n.valueOf()))
             const netCost = await lmsrMarketMaker.calcNetCost.call(outcomeTokenAmounts)
 
             const lmsrMarketMakerOutcomeTokenCounts = await Promise.all(positionIds.map(positionId =>
@@ -471,9 +474,9 @@ contract('LMSRMarketMaker', function (accounts) {
                 } and limit ${
                     netCost
                 } failed while lmsrMarketMaker has:\n\n${
-                    lmsrMarketMakerOutcomeTokenCounts.map(c => c.valueOf()).join('\n')
+                    lmsrMarketMakerOutcomeTokenCounts.map(c => c.toString()).join('\n')
                 }\n\nand ${
-                    lmsrMarketMakerCollateralTokenCount.valueOf()
+                    lmsrMarketMakerCollateralTokenCount.toString()
                 }: ${
                     e.message
                 }`)
@@ -481,8 +484,8 @@ contract('LMSRMarketMaker', function (accounts) {
 
             if(txResult)
                 assert.equal(
-                    getParamFromTxEvent(txResult, 'outcomeTokenNetCost').valueOf(),
-                    netCost.valueOf())
+                    (await getParamFromTxEvent(txResult, 'outcomeTokenNetCost')).toString(),
+                    netCost.toString())
         }
     })
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -6,11 +6,11 @@ const Decimal = require('decimal.js').clone({ precision: PRECISION })
 const ONE = Decimal(2).pow(64)
 
 function isClose(a, b, relTol=1e-9, absTol=1e-18) {
-    return Decimal(a.valueOf()).sub(b).abs().lte(
+    return new Decimal(a.toString()).sub(b).abs().lte(
         Decimal.max(
             Decimal.max(
-                Decimal.abs(a.valueOf()),
-                Decimal.abs(b.valueOf())
+                Decimal.abs(a.toString()),
+                Decimal.abs(b.toString())
             ).mul(relTol),
             absTol))
 }
@@ -24,7 +24,7 @@ function randnums(a, b, n) {
     return _.range(n).map(() => randrange(a, b))
 }
 
-function getParamFromTxEvent(transaction, paramName, contractFactory, eventName) {
+async function getParamFromTxEvent(transaction, paramName, contractFactory, eventName) {
     assert.isObject(transaction)
     let logs = transaction.logs
     if(eventName != null) {
@@ -33,7 +33,7 @@ function getParamFromTxEvent(transaction, paramName, contractFactory, eventName)
     assert.equal(logs.length, 1, `expected one log but got ${logs.length} logs`)
     let param = logs[0].args[paramName]
     if(contractFactory != null) {
-        let contract = contractFactory.at(param)
+        let contract = await contractFactory.at(param)
         assert.isObject(contract, `getting ${paramName} failed for ${param}`)
         return contract
     } else {
@@ -63,13 +63,13 @@ function getBlock(b) {
 }
 
 function lmsrMarginalPrice(funding, netOutcomeTokensSold, outcomeIndex) {
-    const b = new Decimal(funding.valueOf()).div(Decimal.ln(netOutcomeTokensSold.length))
-    const numerator = new Decimal(netOutcomeTokensSold[outcomeIndex].valueOf()).div(b).exp()
+    const b = new Decimal(funding.toString()).div(Decimal.ln(netOutcomeTokensSold.length))
+    const numerator = new Decimal(netOutcomeTokensSold[outcomeIndex].toString()).div(b).exp()
     const denominator = netOutcomeTokensSold.reduce(
-        (acc, tokensSold) => acc.add(Decimal(tokensSold.valueOf()).div(b).exp()),
+        (acc, tokensSold) => acc.add(new Decimal(tokensSold.toString()).div(b).exp()),
         new Decimal(0)
     )
-    return numerator.div(denominator).valueOf()
+    return numerator.div(denominator).toString()
 }
 
 Object.assign(exports, {

--- a/test/utils.js
+++ b/test/utils.js
@@ -63,14 +63,13 @@ function getBlock(b) {
 }
 
 function lmsrMarginalPrice(funding, netOutcomeTokensSold, outcomeIndex) {
-    const b = Decimal(funding.valueOf()).div(netOutcomeTokensSold.length).ln()
-
-    return Decimal(netOutcomeTokensSold[outcomeIndex].valueOf()).div(b).exp().div(
-        netOutcomeTokensSold.reduce(
-            (acc, tokensSold) => acc.add(Decimal(tokensSold.valueOf()).div(b).exp()),
-            Decimal(0)
-        )
-    ).valueOf()
+    const b = new Decimal(funding.valueOf()).div(Decimal.ln(netOutcomeTokensSold.length))
+    const numerator = new Decimal(netOutcomeTokensSold[outcomeIndex].valueOf()).div(b).exp()
+    const denominator = netOutcomeTokensSold.reduce(
+        (acc, tokensSold) => acc.add(Decimal(tokensSold.valueOf()).div(b).exp()),
+        new Decimal(0)
+    )
+    return numerator.div(denominator).valueOf()
 }
 
 Object.assign(exports, {

--- a/truffle.js
+++ b/truffle.js
@@ -24,6 +24,11 @@ const config = {
     mocha: {
         enableTimeouts: false,
         grep: process.env.TEST_GREP
+    },
+    compilers: {
+        solc: {
+            version: "0.4.24",
+        }
     }
 }
 


### PR DESCRIPTION
Last commit migrating to Truffle 5 can be left off or branched off if desired.

Stats diff:
```diff
@@ -28,29 +28,29 @@ Contract: PredictionMarketSystem
 
 Contract: LMSRMarketMakerFactory
   createLMSRMarketMaker:
-    min: 2617702
-    max: 2633086
-    avg: 2623206.153846154
-    med: 2617766
+    min: 2637618
+    max: 2653002
+    avg: 2642341.6923076925
+    med: 2637682
 
 Contract: LMSRMarketMaker
   fund:
-    min: 141446
-    max: 187087
-    avg: 154632.6923076923
-    med: 156446
+    min: 141424
+    max: 187065
+    avg: 154610.6923076923
+    med: 156424
   calcNetCost:
-    min: 84195
+    min: 71813
     max: undefined
     avg: NaN
     med: undefined
   trade:
-    min: 179591
-    max: 366988
-    avg: 213684.49206349207
-    med: 202285
+    min: 161146
+    max: 262185
+    avg: 177444.49206349207
+    med: 166431
   calcMarginalPrice:
-    min: 45422
+    min: 53617
     max: undefined
     avg: NaN
     med: undefined
@@ -60,7 +60,7 @@ Contract: LMSRMarketMaker
     avg: 75142
     med: 75142
   calcMarketFee:
-    min: 22618
+    min: 22596
     max: undefined
     avg: NaN
     med: undefined
@@ -79,5 +79,5 @@ Contract: WETH9
   approve:
     min: 45225
     max: 47209
-    avg: 45547.37037037037
+    avg: 45533.148148148146
     med: 45545
```

Turns out gas reduction is not as significant as originally hoped for. This uses ~20% less gas for the trade function.

calcMarginalPrice is actually _more_ expensive now, which is a bummer. The reason is that it now makes queries to pmSystem for the outcome tokens held data instead querying its local storage for its own accounting of net outcome tokens sold. Though there is theoretically only one exponentiation which has to be done, because of edge cases written in the test scenarios, what should be "one" actually has to be recalculated from the outcome tokens held data sometimes (this happens when funding is way less than the trading activity with the market maker).

Gas measurement tools don't work under the new Truffle. However, the project will now have access to solc 0.5.0.

I have also fixed up the two test cases which have been skipped for the longest time. This changeset actually addresses an issue in the original code, which had been modified with conservative rounding bounds to ensure that the trading stress tests pass. Unfortunately, the rounding error bounds also caused the market maker to price outcome tokens to be _more_ than its corresponding collateral token (by an order of 1e-18 to be fair, but still enough to cause the original tests to fail).

Also, due to the way that ERC 1155 is specified, and due to how onERC1155Received has been implemented in the MarketMaker, the attack I was concerned about with randos sending outcome tokens to the market maker to try and mess with its account should actually not be possible. However, I did disable the guard and run the stress test with random sends of outcome tokens 1000 times, and it passed nonetheless, so I believe that even if somebody were to figure out a way to send outcome tokens to the market maker without going through one of the exposed methods, it would be simply a donation to the market maker and would not affect its operations terribly much.